### PR TITLE
additional data default value assign to {}

### DIFF
--- a/amorphie.workflow.zeebe/Modules/StateManager.cs
+++ b/amorphie.workflow.zeebe/Modules/StateManager.cs
@@ -130,12 +130,12 @@ public static class StateManagerModule
                 newInstanceTransition!.AdditionalData = body.GetProperty($"TRX-{newInstanceTransition.TransitionName}").GetProperty("Data").GetProperty("additionalData").ToString();
                 try
                 {
-                    if(!string.IsNullOrEmpty(newInstanceTransition!.AdditionalData))
-                    additionalDataDynamic = body.GetProperty($"TRX-{newInstanceTransition.TransitionName}").GetProperty("Data").GetProperty("additionalData");
-                       else
-                {
-                    additionalDataDynamic=new {};
-                }
+                    if (!string.IsNullOrEmpty(newInstanceTransition!.AdditionalData))
+                        additionalDataDynamic = body.GetProperty($"TRX-{newInstanceTransition.TransitionName}").GetProperty("Data").GetProperty("additionalData");
+                    else
+                    {
+                        additionalDataDynamic = new { };
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -165,11 +165,11 @@ public static class StateManagerModule
 
             try
             {
-                 if(!string.IsNullOrEmpty(newInstanceTransition!.AdditionalData))
-                additionalDataDynamic = body.GetProperty($"TRX-{transitionName}").GetProperty("Data").GetProperty("additionalData");
+                if (!string.IsNullOrEmpty(newInstanceTransition!.AdditionalData))
+                    additionalDataDynamic = body.GetProperty($"TRX-{transitionName}").GetProperty("Data").GetProperty("additionalData");
                 else
                 {
-                    additionalDataDynamic=new {};
+                    additionalDataDynamic = new { };
                 }
             }
             catch (Exception ex)

--- a/amorphie.workflow.zeebe/Modules/StateManager.cs
+++ b/amorphie.workflow.zeebe/Modules/StateManager.cs
@@ -130,7 +130,12 @@ public static class StateManagerModule
                 newInstanceTransition!.AdditionalData = body.GetProperty($"TRX-{newInstanceTransition.TransitionName}").GetProperty("Data").GetProperty("additionalData").ToString();
                 try
                 {
+                    if(!string.IsNullOrEmpty(newInstanceTransition!.AdditionalData))
                     additionalDataDynamic = body.GetProperty($"TRX-{newInstanceTransition.TransitionName}").GetProperty("Data").GetProperty("additionalData");
+                       else
+                {
+                    additionalDataDynamic=new {};
+                }
                 }
                 catch (Exception ex)
                 {
@@ -160,7 +165,12 @@ public static class StateManagerModule
 
             try
             {
+                 if(!string.IsNullOrEmpty(newInstanceTransition!.AdditionalData))
                 additionalDataDynamic = body.GetProperty($"TRX-{transitionName}").GetProperty("Data").GetProperty("additionalData");
+                else
+                {
+                    additionalDataDynamic=new {};
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:
- Bug Fix: Updated the `StateManager.cs` file to handle the `AdditionalData` property correctly. If the `newInstanceTransition` object has a non-null or non-empty `AdditionalData` value, it is assigned to `additionalDataDynamic`. Otherwise, an empty anonymous object is assigned. This fix ensures proper handling of `AdditionalData` in the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->